### PR TITLE
Fix (most) allocations

### DIFF
--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -162,11 +162,7 @@ end
       f4 = rho_v1*v3 #- B1*B3
       f5 = (kin_en + gamma*p/(gamma - 1))*v1 + 2 * mag_en * vk1_plus[k] - B1 * (vk1_plus[k] * B1 + vk2_plus[k] * B2 + vk3_plus[k] * B3)
 
-      f[3 + (k - 1) * 5 + 1] = f1
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, f1, f2, f3, f4, f5, equations)
     end
     
   else #if orientation == 2
@@ -191,11 +187,7 @@ end
       f4 = rho_v2*v3 #- B2*B3
       f5 = (kin_en + gamma*p/(gamma - 1))*v2 + 2 * mag_en * vk2_plus[k] - B2 * (vk1_plus[k] * B1 + vk2_plus[k] * B2 + vk3_plus[k] * B3)
 
-      f[3 + (k - 1) * 5 + 1] = f1
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, f1, f2, f3, f4, f5, equations)
     end
   end
 
@@ -226,11 +218,7 @@ function source_terms_standard(u, x, t, equations::IdealMhdMultiIonEquations2D)
     s4 = r_rho * (v1_diff * B2 - v2_diff - B1)
     s5 = v1 * s2 + v2 * s3 + v3 * s4
 
-    s[3 + (k - 1) * 5 + 1] = 0
-    s[3 + (k - 1) * 5 + 2] = s2
-    s[3 + (k - 1) * 5 + 3] = s3
-    s[3 + (k - 1) * 5 + 4] = s4
-    s[3 + (k - 1) * 5 + 5] = s5
+    set_component!(s, k, 0, s2, s3, s4, s5, equations)
   end
 
   return SVector(s)
@@ -316,11 +304,7 @@ The term is composed of three parts
       f5 += (v1_plus_ll * B1_ll + v2_plus_ll * B2_ll + v3_plus_ll * B3_ll) * B1_rr
 
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = 0
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, 0, f2, f3, f4, f5, equations)
     end
 
   else #if orientation == 2
@@ -364,11 +348,7 @@ The term is composed of three parts
       f5 += (v1_plus_ll * B1_ll + v2_plus_ll * B2_ll + v3_plus_ll * B3_ll) * B2_rr
       
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = 0
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, 0, f2, f3, f4, f5, equations)
     end
   end
 
@@ -436,11 +416,7 @@ The term is composed of three parts
       # It's not needed to adjust to Trixi's non-conservative form
 
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = 0
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, 0, f2, f3, f4, f5, equations)
     end
   else #if orientation == 2
     # Entries of Powell term for induction equation (already in Trixi's non-conservative form)
@@ -472,11 +448,7 @@ The term is composed of three parts
       # It's not needed to adjust to Trixi's non-conservative form
 
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = 0
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, 0, f2, f3, f4, f5, equations)
     end
   end
 
@@ -590,11 +562,7 @@ function flux_ruedaramirez_etal(u_ll, u_rr, orientation::Integer, equations::Ide
             + 0.5 * vk1_plus_avg * mag_norm_avg - vk1_plus_avg * B1_avg * B1_avg - vk2_plus_avg * B1_avg * B2_avg - vk3_plus_avg * B1_avg * B3_avg   # Additional terms coming from the MHD non-conservative term (momentum eqs)
             - B2_avg *  (vk1_minus_avg * B2_avg - vk2_minus_avg * B1_avg) - B3_avg * (vk1_minus_avg * B3_avg - vk3_minus_avg * B1_avg) )             # Terms coming from the non-conservative term 3 (induction equation!)
 
-      f[3 + (k - 1) * 5 + 1] = f1
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, f1, f2, f3, f4, f5, equations)
     end
   else #if orientation == 2
     # Magnetic field components from f^MHD
@@ -670,11 +638,7 @@ function flux_ruedaramirez_etal(u_ll, u_rr, orientation::Integer, equations::Ide
             + 0.5 * vk2_plus_avg * mag_norm_avg - vk1_plus_avg * B2_avg * B1_avg - vk2_plus_avg * B2_avg * B2_avg - vk3_plus_avg * B2_avg * B3_avg   # Additional terms coming from the MHD non-conservative term (momentum eqs)
             - B1_avg *  (vk2_minus_avg * B1_avg - vk1_minus_avg * B2_avg) - B3_avg * (vk2_minus_avg * B3_avg - vk3_minus_avg * B2_avg) )             # Terms coming from the non-conservative term 3 (induction equation!)
 
-      f[3 + (k - 1) * 5 + 1] = f1
-      f[3 + (k - 1) * 5 + 2] = f2
-      f[3 + (k - 1) * 5 + 3] = f3
-      f[3 + (k - 1) * 5 + 4] = f4
-      f[3 + (k - 1) * 5 + 5] = f5
+      set_component!(f, k, f1, f2, f3, f4, f5, equations)
     end
   end
 
@@ -882,17 +846,30 @@ end
 Get the flow variables of component k
 """
 @inline function get_component(k, u, equations::IdealMhdMultiIonEquations2D)
-  return SVector(u[(k-1)*5+4],
-                 u[(k-1)*5+5],
-                 u[(k-1)*5+6],
-                 u[(k-1)*5+7],
-                 u[(k-1)*5+8])
+  # The first 3 entries of u contain the magnetic field. The following entries contain the density, momentum (3 entries), and energy of each component.
+  return SVector(u[3 + (k - 1) * 5 + 1],
+                 u[3 + (k - 1) * 5 + 2],
+                 u[3 + (k - 1) * 5 + 3],
+                 u[3 + (k - 1) * 5 + 4],
+                 u[3 + (k - 1) * 5 + 5])
+end
+
+"""
+Set the flow variables of component k
+"""
+@inline function set_component!(u, k, u1, u2, u3, u4, u5, equations::IdealMhdMultiIonEquations2D)
+  # The first 3 entries of u contain the magnetic field. The following entries contain the density, momentum (3 entries), and energy of each component.
+  u[3 + (k - 1) * 5 + 1] = u1
+  u[3 + (k - 1) * 5 + 2] = u2
+  u[3 + (k - 1) * 5 + 3] = u3
+  u[3 + (k - 1) * 5 + 4] = u4
+  u[3 + (k - 1) * 5 + 5] = u5
 end
 
 @inline function density_product(u, equations::IdealMhdMultiIonEquations2D)
   prod = one(u[1])
   for k in eachcomponent(equations)
-    prod *= u[(k-1)*5+4]
+    prod *= u[3 + (k - 1) * 5 + 1]
   end
   return prod
 end
@@ -900,7 +877,7 @@ end
 @inline function density(u, equations::IdealMhdMultiIonEquations2D)
   rho = 0
   for k in eachcomponent(equations)
-    rho += u[(k-1)*5+4]
+    rho += u[3 + (k - 1) * 5 + 1]
   end
   return rho
 end

--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -114,8 +114,8 @@ function initial_condition_weak_blast_wave(x, t, equations::IdealMhdMultiIonEqua
   else
     rho = 1.1691
   end
-  v1 = r > 0.5 ? 0 : 0.1882 * cos(phi)
-  v2 = r > 0.5 ? 0 : 0.1882 * sin(phi)
+  v1 = r > 0.5 ? 0.0 : 0.1882 * cos(phi)
+  v2 = r > 0.5 ? 0.0 : 0.1882 * sin(phi)
   p = r > 0.5 ? 1.0 : 1.245
 
   #prim = (0.01, 0.01, 0.01)
@@ -261,7 +261,7 @@ The term is composed of three parts
   # Compute charge ratio of u_ll
   #
   charge_ratio_ll = zeros(MVector{ncomponents(equations), eltype(u_ll)})
-  total_electron_charge = 0
+  total_electron_charge = zero(u_ll[1])
   for k in eachcomponent(equations)
     rho_k = u_ll[(k-1)*5+4]
     charge_ratio_ll[k] = rho_k * charge_to_mass[k]

--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -118,12 +118,15 @@ function initial_condition_weak_blast_wave(x, t, equations::IdealMhdMultiIonEqua
   v2 = r > 0.5 ? 0.0 : 0.1882 * sin(phi)
   p = r > 0.5 ? 1.0 : 1.245
 
-  prim = (1.0, 1.0, 1.0)
-  for i in eachcomponent(equations)
-    prim = (prim..., 2^(i-1) * (1-2)/(1-2^ncomponents(equations)) * rho, v1, v2, zero(real(equations)), p)
+  prim = zero(MVector{nvariables(equations), real(equations)})
+  prim[1] = 1.0
+  prim[2] = 1.0
+  prim[3] = 1.0
+  for k in eachcomponent(equations)
+    set_component!(prim, k, 2^(k-1) * (1-2)/(1-2^ncomponents(equations)) * rho, v1, v2, 0, p, equations)
   end
 
-  return prim2cons(SVector{nvariables(equations), real(equations)}(prim), equations)
+  return prim2cons(SVector(prim), equations)
 end
 
 # TODO: Add initial condition equilibrium

--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -136,7 +136,7 @@ end
 
   mag_en = 0.5 * (B1^2 + B2^2 + B3^2)
 
-  f = zeros(MVector{nvariables(equations), eltype(u)})
+  f = zero(MVector{nvariables(equations), eltype(u)})
 
   if orientation == 1
     f[1] = 0
@@ -199,7 +199,7 @@ function source_terms_standard(u, x, t, equations::IdealMhdMultiIonEquations2D)
   B1, B2, B3, _ = u
   v1_plus, v2_plus, v3_plus, vk1_plus, vk2_plus, vk3_plus = charge_averaged_velocities(u, equations)
 
-  s = zeros(MVector{nvariables(equations), eltype(u)})
+  s = zero(MVector{nvariables(equations), eltype(u)})
 
   for k in eachcomponent(equations)
     rho, rho_v1, rho_v2, rho_v3, rho_e = get_component(k, u, equations)
@@ -245,7 +245,7 @@ The term is composed of three parts
 
   # Compute charge ratio of u_ll
   #
-  charge_ratio_ll = zeros(MVector{ncomponents(equations), eltype(u_ll)})
+  charge_ratio_ll = zero(MVector{ncomponents(equations), eltype(u_ll)})
   total_electron_charge = zero(u_ll[1])
   for k in eachcomponent(equations)
     rho_k = u_ll[(k-1)*5+4]
@@ -258,7 +258,7 @@ The term is composed of three parts
   v1_plus_ll, v2_plus_ll, v3_plus_ll, vk1_plus_ll, vk2_plus_ll, vk3_plus_ll = charge_averaged_velocities(u_ll, equations)
   v1_plus_rr, v2_plus_rr, v3_plus_rr, vk1_plus_rr, vk2_plus_rr, vk3_plus_rr = charge_averaged_velocities(u_rr, equations)
 
-  f = zeros(MVector{nvariables(equations), eltype(u_ll)})
+  f = zero(MVector{nvariables(equations), eltype(u_ll)})
   
   if orientation == 1
     # Entries of Powell term for induction equation (already in Trixi's non-conservative form)
@@ -369,7 +369,7 @@ The term is composed of three parts
   mag_norm_rr = B1_rr^2 + B2_rr^2 + B3_rr^2
 
   # Compute charge ratio of u_ll
-  charge_ratio_ll = zeros(MVector{ncomponents(equations), eltype(u_ll)})
+  charge_ratio_ll = zero(MVector{ncomponents(equations), eltype(u_ll)})
   total_electron_charge = zero(real(equations))
   for k in eachcomponent(equations)
     rho_k = u_ll[(k-1)*5+4]
@@ -382,7 +382,7 @@ The term is composed of three parts
   v1_plus_ll, v2_plus_ll, v3_plus_ll, vk1_plus_ll, vk2_plus_ll, vk3_plus_ll = charge_averaged_velocities(u_ll, equations)
   v1_plus_rr, v2_plus_rr, v3_plus_rr, vk1_plus_rr, vk2_plus_rr, vk3_plus_rr = charge_averaged_velocities(u_rr, equations)
 
-  f = zeros(MVector{nvariables(equations), eltype(u_ll)})
+  f = zero(MVector{nvariables(equations), eltype(u_ll)})
   
   if orientation == 1
     # Entries of Powell term for induction equation (already in Trixi's non-conservative form)
@@ -472,7 +472,7 @@ function flux_ruedaramirez_etal(u_ll, u_rr, orientation::Integer, equations::Ide
   v1_plus_ll, v2_plus_ll, v3_plus_ll, vk1_plus_ll, vk2_plus_ll, vk3_plus_ll = charge_averaged_velocities(u_ll, equations)
   v1_plus_rr, v2_plus_rr, v3_plus_rr, vk1_plus_rr, vk2_plus_rr, vk3_plus_rr = charge_averaged_velocities(u_rr, equations)
 
-  f = zeros(MVector{nvariables(equations), eltype(u_ll)})
+  f = zero(MVector{nvariables(equations), eltype(u_ll)})
 
   # Compute averages for global variables
   v1_plus_avg = 0.5*(v1_plus_ll+v1_plus_rr)
@@ -815,9 +815,9 @@ Routine to compute the Charge-averaged velocities:
 
   total_electron_charge = zero(real(equations))
   
-  vk1_plus = zeros(MVector{ncomponents(equations), eltype(u)})
-  vk2_plus = zeros(MVector{ncomponents(equations), eltype(u)})
-  vk3_plus = zeros(MVector{ncomponents(equations), eltype(u)})
+  vk1_plus = zero(MVector{ncomponents(equations), eltype(u)})
+  vk2_plus = zero(MVector{ncomponents(equations), eltype(u)})
+  vk3_plus = zero(MVector{ncomponents(equations), eltype(u)})
 
   for k in eachcomponent(equations)
     rho_k = u[(k-1)*5+4]

--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -142,7 +142,7 @@ end
   f = zeros(MVector{nvariables(equations), eltype(u)})
 
   if orientation == 1
-    f[1] = 0.0
+    f[1] = 0
     f[2] = v1_plus * B2 - v2_plus * B1
     f[3] = v1_plus * B3 - v3_plus * B1
 
@@ -172,7 +172,7 @@ end
   else #if orientation == 2
 
     f[1] = v2_plus * B1 - v1_plus * B2
-    f[2] = 0.0
+    f[2] = 0
     f[3] = v2_plus * B3 - v3_plus * B2
 
     for k in eachcomponent(equations)

--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -244,7 +244,6 @@ The term is composed of three parts
   mag_norm_avg = 0.5*(mag_norm_ll+mag_norm_rr)
 
   # Compute charge ratio of u_ll
-  #
   charge_ratio_ll = zero(MVector{ncomponents(equations), eltype(u_ll)})
   total_electron_charge = zero(u_ll[1])
   for k in eachcomponent(equations)
@@ -654,8 +653,8 @@ end
   cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
 
   # Calculate velocities
-  v_ll = 0
-  v_rr = 0
+  v_ll = zero(u_ll[1])
+  v_rr = zero(u_rr[1])
   if orientation == 1
     for k in eachcomponent(equations)
       rho, rho_v1, _ = get_component(k, u_ll, equations)

--- a/src/equations/ideal_mhd_multiion_2d.jl
+++ b/src/equations/ideal_mhd_multiion_2d.jl
@@ -76,7 +76,7 @@ default_analysis_integrals(::IdealMhdMultiIonEquations2D)  = (entropy_timederiva
 
 #   rho = 1.0
 #   prim_rho  = SVector{ncomponents(equations), real(equations)}(2^(i-1) * (1-2)/(1-2^ncomponents(equations)) * rho for i in eachcomponent(equations))
-#   v1 = 0.0
+#   v1 = 0
 #   si, co = sincos(2 * pi * x[1])
 #   v2 = 0.1 * si
 #   v3 = 0.1 * co
@@ -108,22 +108,22 @@ function initial_condition_weak_blast_wave(x, t, equations::IdealMhdMultiIonEqua
   phi = atan(y_norm, x_norm)
 
   # Calculate primitive variables
-  rho = zero(real(equations))
+  rho = 0
   if r > 0.5
     rho = 1.0
   else
     rho = 1.1691
   end
-  v1 = r > 0.5 ? 0.0 : 0.1882 * cos(phi)
-  v2 = r > 0.5 ? 0.0 : 0.1882 * sin(phi)
+  v1 = r > 0.5 ? 0 : 0.1882 * cos(phi)
+  v2 = r > 0.5 ? 0 : 0.1882 * sin(phi)
   p = r > 0.5 ? 1.0 : 1.245
 
   #prim = (0.01, 0.01, 0.01)
   prim = (1.0, 1.0, 1.0)
   for i in eachcomponent(equations)
-    prim = (prim..., 2^(i-1) * (1-2)/(1-2^ncomponents(equations)) * rho, v1, v2, 0.0, p)
-    #prim = (prim..., rho, v1, 0.0, 0.0, p)
-    #prim = (prim..., 1.0, 1.0, 0.0, 0.0, 100.0)
+    prim = (prim..., 2^(i-1) * (1-2)/(1-2^ncomponents(equations)) * rho, v1, v2, 0, p)
+    #prim = (prim..., rho, v1, 0, 0, p)
+    #prim = (prim..., 1.0, 1.0, 0, 0, 100)
   end
 
   return prim2cons(SVector{nvariables(equations), real(equations)}(prim), equations)
@@ -226,7 +226,7 @@ function source_terms_standard(u, x, t, equations::IdealMhdMultiIonEquations2D)
     s4 = r_rho * (v1_diff * B2 - v2_diff - B1)
     s5 = v1 * s2 + v2 * s3 + v3 * s4
 
-    s[3 + (k - 1) * 5 + 1] = zero(u[1])
+    s[3 + (k - 1) * 5 + 1] = 0
     s[3 + (k - 1) * 5 + 2] = s2
     s[3 + (k - 1) * 5 + 3] = s3
     s[3 + (k - 1) * 5 + 4] = s4
@@ -261,7 +261,7 @@ The term is composed of three parts
   # Compute charge ratio of u_ll
   #
   charge_ratio_ll = zeros(MVector{ncomponents(equations), eltype(u_ll)})
-  total_electron_charge = zero(u_ll[1])
+  total_electron_charge = 0
   for k in eachcomponent(equations)
     rho_k = u_ll[(k-1)*5+4]
     charge_ratio_ll[k] = rho_k * charge_to_mass[k]
@@ -287,7 +287,7 @@ The term is composed of three parts
       f2 = charge_ratio_ll[k] * (0.5 * mag_norm_avg - B1_avg * B1_avg) # + pe_mean)
       f3 = charge_ratio_ll[k] * (- B1_avg * B2_avg)
       f4 = charge_ratio_ll[k] * (- B1_avg * B3_avg)
-      f5 = zero(u_ll[1]) # TODO! charge_ratio_ll[k] * pe_mean
+      f5 = 0 # TODO: Add "average" of electron pressure! charge_ratio_ll[k] * pe_mean
 
       # Compute term 3 (only needed for NCOMP>1)
       vk1_minus_ll = v1_plus_ll - vk1_plus_ll[k]
@@ -316,7 +316,7 @@ The term is composed of three parts
       f5 += (v1_plus_ll * B1_ll + v2_plus_ll * B2_ll + v3_plus_ll * B3_ll) * B1_rr
 
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = zero(u_ll[1])
+      f[3 + (k - 1) * 5 + 1] = 0
       f[3 + (k - 1) * 5 + 2] = f2
       f[3 + (k - 1) * 5 + 3] = f3
       f[3 + (k - 1) * 5 + 4] = f4
@@ -335,7 +335,7 @@ The term is composed of three parts
       f2 = charge_ratio_ll[k] * (- B2_avg * B1_avg) 
       f3 = charge_ratio_ll[k] * (- B2_avg * B2_avg + 0.5 * mag_norm_avg) # + pe_mean)
       f4 = charge_ratio_ll[k] * (- B2_avg * B3_avg)
-      f5 = zero(u_ll[1]) # TODO! charge_ratio_ll[k] * pe_mean
+      f5 = 0 # TODO: Add average of electron pressure! charge_ratio_ll[k] * pe_mean
 
       # Compute term 3 (only needed for NCOMP>1)
       vk1_minus_ll = v1_plus_ll - vk1_plus_ll[k]
@@ -364,7 +364,7 @@ The term is composed of three parts
       f5 += (v1_plus_ll * B1_ll + v2_plus_ll * B2_ll + v3_plus_ll * B3_ll) * B2_rr
       
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = zero(u_ll[1])
+      f[3 + (k - 1) * 5 + 1] = 0
       f[3 + (k - 1) * 5 + 2] = f2
       f[3 + (k - 1) * 5 + 3] = f3
       f[3 + (k - 1) * 5 + 4] = f4
@@ -393,7 +393,7 @@ The term is composed of three parts
 
   # Compute charge ratio of u_ll
   charge_ratio_ll = zeros(MVector{ncomponents(equations), eltype(u_ll)})
-  total_electron_charge = zero(u_ll[1])
+  total_electron_charge = 0
   for k in eachcomponent(equations)
     rho_k = u_ll[(k-1)*5+4]
     charge_ratio_ll[k] = rho_k * charge_to_mass[k]
@@ -418,7 +418,7 @@ The term is composed of three parts
       f2 = charge_ratio_ll[k] * (0.5 * mag_norm_rr - B1_rr * B1_rr) # + pe_mean)
       f3 = charge_ratio_ll[k] * (- B1_rr * B2_rr)
       f4 = charge_ratio_ll[k] * (- B1_rr * B3_rr)
-      f5 = zero(u_ll[1]) # TODO! charge_ratio_ll[k] * pe_mean
+      f5 = 0 # TODO! charge_ratio_ll[k] * pe_mean
 
       # Compute term 3 (only needed for NCOMP>1)
       vk1_minus_rr = v1_plus_rr - vk1_plus_rr[k]
@@ -436,7 +436,7 @@ The term is composed of three parts
       # It's not needed to adjust to Trixi's non-conservative form
 
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = zero(u_ll[1])
+      f[3 + (k - 1) * 5 + 1] = 0
       f[3 + (k - 1) * 5 + 2] = f2
       f[3 + (k - 1) * 5 + 3] = f3
       f[3 + (k - 1) * 5 + 4] = f4
@@ -454,7 +454,7 @@ The term is composed of three parts
       f2 = charge_ratio_ll[k] * (- B2_rr * B1_rr) 
       f3 = charge_ratio_ll[k] * (- B2_rr * B2_rr + 0.5 * mag_norm_rr) # + pe_mean)
       f4 = charge_ratio_ll[k] * (- B2_rr * B3_rr)
-      f5 = zero(u_ll[1]) # TODO! charge_ratio_ll[k] * pe_mean
+      f5 = 0 # TODO! charge_ratio_ll[k] * pe_mean
 
       # Compute term 3 (only needed for NCOMP>1)
       vk1_minus_rr = v1_plus_rr - vk1_plus_rr[k]
@@ -472,7 +472,7 @@ The term is composed of three parts
       # It's not needed to adjust to Trixi's non-conservative form
 
       # Append to the flux vector
-      f[3 + (k - 1) * 5 + 1] = zero(u_ll[1])
+      f[3 + (k - 1) * 5 + 1] = 0
       f[3 + (k - 1) * 5 + 2] = f2
       f[3 + (k - 1) * 5 + 3] = f3
       f[3 + (k - 1) * 5 + 4] = f4
@@ -518,7 +518,7 @@ function flux_ruedaramirez_etal(u_ll, u_rr, orientation::Integer, equations::Ide
 
   if orientation == 1
     # Magnetic field components from f^MHD
-    f6 = zero(u_ll[1])
+    f6 = 0
     f7 = v1_plus_avg * B2_avg - v2_plus_avg * B1_avg
     f8 = v1_plus_avg * B3_avg - v3_plus_avg * B1_avg
 
@@ -599,7 +599,7 @@ function flux_ruedaramirez_etal(u_ll, u_rr, orientation::Integer, equations::Ide
   else #if orientation == 2
     # Magnetic field components from f^MHD
     f6 = v2_plus_avg * B1_avg - v1_plus_avg * B2_avg
-    f7 = zero(u_ll[1])
+    f7 = 0
     f8 = v2_plus_avg * B3_avg - v3_plus_avg * B2_avg
 
     # Start building the flux
@@ -693,8 +693,8 @@ end
   cf_rr = calc_fast_wavespeed(u_rr, orientation, equations)
 
   # Calculate velocities
-  v_ll = zero(u_ll[1])
-  v_rr = zero(u_rr[1])
+  v_ll = 0
+  v_rr = 0
   if orientation == 1
     for k in eachcomponent(equations)
       rho, rho_v1, _ = get_component(k, u_ll, equations)
@@ -717,8 +717,8 @@ end
 
 @inline function max_abs_speeds(u, equations::IdealMhdMultiIonEquations2D)
   
-  v1 = zero(u[1])
-  v2 = zero(u[1])
+  v1 = 0
+  v2 = 0
   for k in eachcomponent(equations)
     rho, rho_v1, rho_v2, _ = get_component(k, u, equations)
     v1 = max(v1, abs(rho_v1 / rho))
@@ -764,7 +764,7 @@ Convert conservative variables to entropy
 
   prim = cons2prim(u, equations)
   entropy = ()
-  rho_p_plus = zero(u[1])
+  rho_p_plus = 0
   for k in eachcomponent(equations)
     rho, v1, v2, v3, p = get_component(k, prim, equations)
     s = log(p) - gammas[k] * log(rho)
@@ -817,7 +817,7 @@ Compute the fastest wave speed for ideal MHD equations: c_f, the fast magnetoaco
 @inline function calc_fast_wavespeed(cons, orientation::Integer, equations::IdealMhdMultiIonEquations2D)
   B1, B2, B3, _ = cons
 
-  c_f = zero(cons[1])
+  c_f = 0
   for k in eachcomponent(equations)
     rho, rho_v1, rho_v2, rho_v3, rho_e = get_component(k, cons, equations)
     
@@ -852,7 +852,7 @@ Routine to compute the Charge-averaged velocities:
 """
 @inline function charge_averaged_velocities(u, equations::IdealMhdMultiIonEquations2D)
 
-  total_electron_charge = zero(eltype(u))
+  total_electron_charge = 0
   
   vk1_plus = zeros(MVector{ncomponents(equations), eltype(u)})
   vk2_plus = zeros(MVector{ncomponents(equations), eltype(u)})
@@ -898,7 +898,7 @@ end
 end
 
 @inline function density(u, equations::IdealMhdMultiIonEquations2D)
-  rho = zero(u[1])
+  rho = 0
   for k in eachcomponent(equations)
     rho += u[(k-1)*5+4]
   end
@@ -910,8 +910,8 @@ Computes the sum of the densities times the sum of the pressures
 """
 @inline function density_pressure(u, equations::IdealMhdMultiIonEquations2D)
   B1, B2, B3, _ = u
-  rho_total = zero(u[1])
-  p_total = zero(u[1])
+  rho_total = 0
+  p_total = 0
   for k in eachcomponent(equations)
     rho, rho_v1, rho_v2, rho_v3, rho_e = get_component(k, u, equations)
     


### PR DESCRIPTION
For `trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_mhdmultiion_ec.jl"), tspan=(0.0, 0.01))`, I get approximately a speedup of 100x for the `time/DOF/rhs!` metric. There were two main causes for the spurious allocations:
* Type instabilities due to an extension of a tuple with splatting:
  ```julia
  f = (a, b, c)
  [...]
  f = (f..., d, e, f)
  ```
  where the extension was in a loop. This caused `f` to be inferred as `Tuple{Vararg{Float64}}`, i.e., Julia was not able to figure out how long this tuple would be at the end of the loop.
* Use of `zeros(Float64, some_length)`, i.e., explicit heap allocations
* Memory allocations in `get_component` due to array slicing (which causes the data to be copied)

For me, the easiest approach (in terms of implementation, but also conceptually) was to use `MVector`s, which are mutable versions of `SVector` and which, according to @ranocha, do not cause allocations if they do not leave a function scope. This non-allocating behavior was confirmed in my tests.

What's missing is some allocations in `calc_sources!`, which I was not able to further track down, since they did not occur when I manually called the function using `@btime` 🤷‍♂️ Maybe @ranocha has an idea to proceed further?

For future reference, @amrueda, at the bottom of this post I have copied the auxiliary code I used to set up a simulation such that I could benchmark individual functions.

### Before (branch `multi_ion_mhd`)
`time/DOF/rhs!: 5.52488354e-05`

**Timer output:**
```
 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              4.25s / 100.0%           3.17GiB / 100.0%

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 rhs!                          16    3.59s   84.6%   224ms   2.70GiB   85.2%   173MiB
   volume integral             16    2.88s   67.8%   180ms   2.28GiB   71.9%   146MiB
   source terms                16    453ms   10.7%  28.3ms    258MiB    7.9%  16.1MiB
   interface flux              16    255ms    6.0%  15.9ms    173MiB    5.3%  10.8MiB
   prolong2interfaces          16   2.14ms    0.1%   133μs     0.00B    0.0%    0.00B
   surface integral            16    979μs    0.0%  61.2μs     0.00B    0.0%    0.00B
   ~rhs!~                      16    138μs    0.0%  8.61μs   9.33KiB    0.0%     597B
   reset ∂u/∂t                 16    131μs    0.0%  8.21μs     0.00B    0.0%    0.00B
   Jacobian                    16    126μs    0.0%  7.85μs     0.00B    0.0%    0.00B
   prolong2mortars             16   12.8μs    0.0%   799ns     0.00B    0.0%    0.00B
   prolong2boundaries          16   10.8μs    0.0%   676ns     0.00B    0.0%    0.00B
   mortar flux                 16   7.74μs    0.0%   484ns     0.00B    0.0%    0.00B
   boundary flux               16   1.46μs    0.0%  91.2ns     0.00B    0.0%    0.00B
 analyze solution               2    634ms   14.9%   317ms    462MiB   14.2%   231MiB
 I/O                            3   15.9ms    0.4%  5.29ms   10.1MiB    0.3%  3.36MiB
   save solution                2   14.3ms    0.3%  7.15ms   10.0MiB    0.3%  5.02MiB
   ~I/O~                        3   1.54ms    0.0%   512μs   34.1KiB    0.0%  11.4KiB
   get element variables        2   18.0μs    0.0%  9.01μs   3.97KiB    0.0%  1.98KiB
   save mesh                    2    240ns    0.0%   120ns     0.00B    0.0%    0.00B
 calculate dt                   4   4.41ms    0.1%  1.10ms   9.00MiB    0.3%  2.25MiB
 ────────────────────────────────────────────────────────────────────────────────────
```

### After (this PR):
`time/DOF/rhs!: 5.80463853e-07`

**Timer output:**
```
 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              252ms /  99.7%            118MiB /  99.6%

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 analyze solution               2    196ms   78.1%  98.0ms    109MiB   92.7%  54.4MiB
 rhs!                          16   38.0ms   15.1%  2.37ms   14.6KiB    0.0%     933B
   volume integral             16   29.8ms   11.9%  1.87ms     0.00B    0.0%    0.00B
   interface flux              16   5.16ms    2.1%   322μs     0.00B    0.0%    0.00B
   prolong2interfaces          16   1.12ms    0.4%  70.2μs     0.00B    0.0%    0.00B
   source terms                16   1.06ms    0.4%  66.5μs   5.25KiB    0.0%     336B
   surface integral            16    525μs    0.2%  32.8μs     0.00B    0.0%    0.00B
   Jacobian                    16    117μs    0.0%  7.34μs     0.00B    0.0%    0.00B
   reset ∂u/∂t                 16    114μs    0.0%  7.14μs     0.00B    0.0%    0.00B
   ~rhs!~                      16   25.1μs    0.0%  1.57μs   9.33KiB    0.0%     597B
   prolong2mortars             16   1.37μs    0.0%  85.6ns     0.00B    0.0%    0.00B
   prolong2boundaries          16   1.20μs    0.0%  75.0ns     0.00B    0.0%    0.00B
   mortar flux                 16    880ns    0.0%  55.0ns     0.00B    0.0%    0.00B
   boundary flux               16    340ns    0.0%  21.2ns     0.00B    0.0%    0.00B
 I/O                            3   15.9ms    6.4%  5.31ms   8.57MiB    7.3%  2.86MiB
   save solution                2   13.8ms    5.5%  6.91ms   8.54MiB    7.3%  4.27MiB
   ~I/O~                        3   2.10ms    0.8%   700μs   34.1KiB    0.0%  11.4KiB
   get element variables        2   14.4μs    0.0%  7.21μs   3.97KiB    0.0%  1.98KiB
   save mesh                    2    170ns    0.0%  85.0ns     0.00B    0.0%    0.00B
 calculate dt                   4   1.11ms    0.4%   278μs     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────
```

This is the file I used as a starting point for benchmarking (`mwe.jl`); the function that I benchmarked of course changed later on:
```julia
using Trixi, BenchmarkTools

@info "Running elixir..."
trixi_include(joinpath(examples_dir(), "tree_2d_dgsem", "elixir_mhdmultiion_ec.jl"), tspan=(0.0, 0.01))

@info "Creating dummy data..."
u_ode = deepcopy(ode.u0)
du_ode = similar(u_ode)

u = Trixi.wrap_array(u_ode, semi)
du = Trixi.wrap_array(du_ode, semi)
u_node = Trixi.get_node_vars(u, equations, solver, 1, 1, 1)

@info "Running rhs!..."
@time Trixi.rhs!(du, u, 0.0, mesh, equations, semi.initial_condition, semi.boundary_conditions,
                 semi.source_terms, solver, semi.cache)

@info "Benchmarking charge_averaged_velocities..."
@btime Trixi.charge_averaged_velocities($u_node, $equations)
```
Note that not all code is strictly necessary, e.g., you do not necessarily need to set up all these data structures to be able to call `rhs!`, but it helped me to descend gently into the madness 😬 