### PR TITLE
WIP: Improve performance of subcell limiting for non-conservative systems

### DIFF
--- a/examples/tree_2d_dgsem/convergence_subcell/elixir_mhd_alfven_wave_fluxdifferencing.jl
+++ b/examples/tree_2d_dgsem/convergence_subcell/elixir_mhd_alfven_wave_fluxdifferencing.jl
@@ -1,0 +1,71 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible ideal GLM-MHD equations
+gamma = 5 / 3
+equations = IdealGlmMhdEquations2D(gamma)
+
+initial_condition = initial_condition_convergence_test
+
+volume_flux = (flux_central, flux_nonconservative_powell2)
+surface_flux = (flux_lax_friedrichs, flux_nonconservative_powell2)
+
+basis = LobattoLegendreBasis(3)
+volume_integral = VolumeIntegralFluxDifferencing(volume_flux)
+
+solver = DGSEM(polydeg = 3,
+               surface_flux = surface_flux,
+               volume_integral = volume_integral)
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (sqrt(2.0), sqrt(2.0))
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 10_000)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 2.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
+                                     save_analysis = true,
+                                     extra_analysis_integrals = (entropy, energy_total,
+                                                                 energy_kinetic,
+                                                                 energy_internal,
+                                                                 energy_magnetic,
+                                                                 cross_helicity))
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(interval = 10,
+                                     save_initial_solution = true,
+                                     save_final_solution = true,
+                                     solution_variables = cons2prim)
+
+cfl = 0.5
+stepsize_callback = StepsizeCallback(cfl = cfl)
+
+glm_speed_callback = GlmSpeedCallback(glm_scale = 0.5, cfl = cfl)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        save_solution,
+                        stepsize_callback,
+                        glm_speed_callback)
+
+###############################################################################
+# run the simulation
+sol = Trixi.solve(ode, Trixi.SimpleSSPRK33(); #
+                  dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+                  save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/examples/tree_2d_dgsem/convergence_subcell/elixir_mhd_alfven_wave_subcell.jl
+++ b/examples/tree_2d_dgsem/convergence_subcell/elixir_mhd_alfven_wave_subcell.jl
@@ -1,0 +1,78 @@
+
+using OrdinaryDiffEq
+using Trixi
+
+###############################################################################
+# semidiscretization of the compressible ideal GLM-MHD equations
+gamma = 5 / 3
+equations = IdealGlmMhdEquations2D(gamma)
+
+initial_condition = initial_condition_convergence_test
+
+volume_flux = (flux_central, flux_nonconservative_powell2)
+surface_flux = (flux_lax_friedrichs, flux_nonconservative_powell2)
+
+basis = LobattoLegendreBasis(3)
+limiter_idp = SubcellLimiterIDP(equations, basis;
+                                positivity_variables_cons=[1],
+                                positivity_correction_factor=0.1)
+volume_integral = VolumeIntegralSubcellLimiting(limiter_idp;
+                                                volume_flux_dg=volume_flux,
+                                                volume_flux_fv=surface_flux)
+
+solver = DGSEM(polydeg = 3,
+               surface_flux = surface_flux,
+               volume_integral = volume_integral)
+
+coordinates_min = (0.0, 0.0)
+coordinates_max = (sqrt(2.0), sqrt(2.0))
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 4,
+                n_cells_max = 100_000)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 2.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
+                                     save_analysis = true,
+                                     extra_analysis_integrals = (entropy, energy_total,
+                                                                 energy_kinetic,
+                                                                 energy_internal,
+                                                                 energy_magnetic,
+                                                                 cross_helicity))
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(interval = 10,
+                                     save_initial_solution = true,
+                                     save_final_solution = true,
+                                     solution_variables = cons2prim)
+
+cfl = 0.5
+stepsize_callback = StepsizeCallback(cfl = cfl)
+
+glm_speed_callback = GlmSpeedCallback(glm_scale = 0.5, cfl = cfl)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        save_solution,
+                        stepsize_callback,
+                        glm_speed_callback)
+
+###############################################################################
+# run the simulation
+stage_callbacks = (SubcellLimiterIDPCorrection(),)
+
+sol = Trixi.solve(ode, Trixi.SimpleSSPRK33(stage_callbacks = stage_callbacks); #
+                  dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+                  save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
@@ -77,9 +77,11 @@ end
     fhat1_R = fhat1_R_threaded[Threads.threadid()]
     fhat2_L = fhat2_L_threaded[Threads.threadid()]
     fhat2_R = fhat2_R_threaded[Threads.threadid()]
-    calcflux_fhat!(fhat1_L, fhat1_R, fhat2_L, fhat2_R, u, mesh,
-                   nonconservative_terms, equations, volume_flux_dg, dg, element,
-                   cache)
+    @trixi_timeit timer() "calcflux_fhat!" begin
+        calcflux_fhat!(fhat1_L, fhat1_R, fhat2_L, fhat2_R, u, mesh,
+                       nonconservative_terms, equations, volume_flux_dg, dg, element,
+                       cache)
+    end
 
     # low-order FV fluxes
     @unpack fstar1_L_threaded, fstar1_R_threaded, fstar2_L_threaded, fstar2_R_threaded = cache

--- a/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
@@ -282,15 +282,19 @@ end
         u_rr = get_node_vars(u, equations, dg, i + 1, j, element)
         for noncons in 1:nnoncons(equations)
             for v in eachvariable(equations)
-                fhat_noncons_temp[v, noncons, i + 1, j] = fhat_noncons_temp[v, noncons, i,
+                fhat_noncons_temp[v, noncons, i + 1, j] = fhat_noncons_temp[v, noncons,
+                                                                            i,
                                                                             j] +
-                                                        weights[i] *
-                                                        flux_noncons_temp[v, noncons, i,
+                                                          weights[i] *
+                                                          flux_noncons_temp[v, noncons,
+                                                                            i,
                                                                             j]
             end
-            volume_flux_noncons(view(fhat1_L,:, i + 1, j), view(fhat_noncons_temp,:, noncons, i + 1, j), 
+            volume_flux_noncons(view(fhat1_L, :, i + 1, j),
+                                view(fhat_noncons_temp, :, noncons, i + 1, j),
                                 u_ll, 1, equations, NonConservativeLocal(), noncons)
-            volume_flux_noncons(view(fhat1_R,:, i + 1, j), view(fhat_noncons_temp,:, noncons, i + 1, j), 
+            volume_flux_noncons(view(fhat1_R, :, i + 1, j),
+                                view(fhat_noncons_temp, :, noncons, i + 1, j),
                                 u_rr, 1, equations, NonConservativeLocal(), noncons)
         end
     end
@@ -342,15 +346,19 @@ end
         u_rr = get_node_vars(u, equations, dg, i, j + 1, element)
         for noncons in 1:nnoncons(equations)
             for v in eachvariable(equations)
-                fhat_noncons_temp[v, noncons, i, j + 1] = fhat_noncons_temp[v, noncons, i,
+                fhat_noncons_temp[v, noncons, i, j + 1] = fhat_noncons_temp[v, noncons,
+                                                                            i,
                                                                             j] +
-                                                        weights[j] *
-                                                        flux_noncons_temp[v, noncons, i,
+                                                          weights[j] *
+                                                          flux_noncons_temp[v, noncons,
+                                                                            i,
                                                                             j]
             end
-            volume_flux_noncons(view(fhat2_L,:, i, j + 1), view(fhat_noncons_temp,:, noncons, i, j + 1), 
+            volume_flux_noncons(view(fhat2_L, :, i, j + 1),
+                                view(fhat_noncons_temp, :, noncons, i, j + 1),
                                 u_ll, 2, equations, NonConservativeLocal(), noncons)
-            volume_flux_noncons(view(fhat2_R,:, i, j + 1), view(fhat_noncons_temp,:, noncons, i, j + 1), 
+            volume_flux_noncons(view(fhat2_R, :, i, j + 1),
+                                view(fhat_noncons_temp, :, noncons, i, j + 1),
                                 u_rr, 2, equations, NonConservativeLocal(), noncons)
         end
     end

--- a/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
@@ -281,6 +281,8 @@ end
             fhat1_R[v, i + 1, j] = fhat_temp[v, i + 1, j]
         end
         # Nonconservative part
+        u_ll = get_node_vars(u, equations, dg, i, j, element)
+        u_rr = get_node_vars(u, equations, dg, i + 1, j, element)
         for noncons in 1:nnoncons(equations)
             for v in eachvariable(equations)
                 fhat_noncons_temp[v, noncons, i + 1, j] = fhat_noncons_temp[v, noncons, i,
@@ -289,10 +291,8 @@ end
                                                         flux_noncons_temp[v, noncons, i,
                                                                             j]
             end
-            u_ll = get_node_vars(u, equations, dg, i, j, element)
             volume_flux_noncons(view(fhat1_L,:, i + 1, j), view(fhat_noncons_temp,:, noncons, i + 1, j), 
                                 u_ll, 1, equations, NonConservativeLocal(), noncons)
-            u_rr = get_node_vars(u, equations, dg, i + 1, j, element)
             volume_flux_noncons(view(fhat1_R,:, i + 1, j), view(fhat_noncons_temp,:, noncons, i + 1, j), 
                                 u_rr, 1, equations, NonConservativeLocal(), noncons)
         end
@@ -341,6 +341,8 @@ end
             fhat2_R[v, i, j + 1] = fhat_temp[v, i, j + 1]
         end
         # Nonconservative part
+        u_ll = get_node_vars(u, equations, dg, i, j, element)
+        u_rr = get_node_vars(u, equations, dg, i, j + 1, element)
         for noncons in 1:nnoncons(equations)
             for v in eachvariable(equations)
                 fhat_noncons_temp[v, noncons, i, j + 1] = fhat_noncons_temp[v, noncons, i,
@@ -349,10 +351,8 @@ end
                                                         flux_noncons_temp[v, noncons, i,
                                                                             j]
             end
-            u_ll = get_node_vars(u, equations, dg, i, j, element)
             volume_flux_noncons(view(fhat2_L,:, i, j + 1), view(fhat_noncons_temp,:, noncons, i, j + 1), 
                                 u_ll, 2, equations, NonConservativeLocal(), noncons)
-            u_rr = get_node_vars(u, equations, dg, i, j + 1, element)
             volume_flux_noncons(view(fhat2_R,:, i, j + 1), view(fhat_noncons_temp,:, noncons, i, j + 1), 
                                 u_rr, 2, equations, NonConservativeLocal(), noncons)
         end


### PR DESCRIPTION
This is an ugly hack to improve the performance in the computation of the subcell limiting formula.

We avoid a lot of multiplications and additions with 0. As a result, the computation of the DG staggered fluxes goes from `2.30μs` to `1.76μs`  (`time/DOF/rhs!` goes from `2.61561070e-07 s` to `2.37202532e-07 s`). However, the non-conservative fluxes become less readable...

This PR requires that the non-conservative flux functions that are called by `VolumeIntegralSubcellLimiting` modify their arguments. So far, I have not followed the "exclamation mark convention" to allow multiple dispatch on `volume_flux`.

This is the *new* performance summary of the test referenced in https://github.com/trixi-framework/Trixi.jl/pull/1670:
```
 ─────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                       Time                    Allocations      
                                    ───────────────────────   ────────────────────────
          Tot / % measured:              367ms /  98.2%           19.6MiB /  99.2%    

 Section                    ncalls     time    %tot     avg     alloc    %tot      avg
 ─────────────────────────────────────────────────────────────────────────────────────
 rhs!                          306    296ms   82.0%   966μs   10.1KiB    0.1%    33.7B
   volume integral             306    250ms   69.3%   818μs      752B    0.0%    2.46B
     calcflux_fhat!          78.3k    138ms   38.3%  1.76μs     0.00B    0.0%    0.00B
     ~volume integral~         306    112ms   31.1%   366μs      752B    0.0%    2.46B
   interface flux              306   34.6ms    9.6%   113μs     0.00B    0.0%    0.00B
   surface integral            306   4.04ms    1.1%  13.2μs     0.00B    0.0%    0.00B
   prolong2interfaces          306   3.81ms    1.1%  12.5μs     0.00B    0.0%    0.00B
   Jacobian                    306   1.64ms    0.5%  5.36μs     0.00B    0.0%    0.00B
   reset ∂u/∂t                 306   1.04ms    0.3%  3.41μs     0.00B    0.0%    0.00B
   ~rhs!~                      306    326μs    0.1%  1.06μs   9.33KiB    0.0%    31.2B
   prolong2boundaries          306   18.5μs    0.0%  60.4ns     0.00B    0.0%    0.00B
   prolong2mortars             306   13.7μs    0.0%  44.8ns     0.00B    0.0%    0.00B
   mortar flux                 306   9.62μs    0.0%  31.4ns     0.00B    0.0%    0.00B
   boundary flux               306   6.73μs    0.0%  22.0ns     0.00B    0.0%    0.00B
   source terms                306   6.56μs    0.0%  21.4ns     0.00B    0.0%    0.00B
 I/O                            13   31.9ms    8.8%  2.45ms   10.5MiB   54.0%   828KiB
   save solution                12   30.8ms    8.5%  2.56ms   10.4MiB   53.2%   885KiB
   ~I/O~                        13    791μs    0.2%  60.8μs   40.8KiB    0.2%  3.14KiB
   get element variables        12    283μs    0.1%  23.6μs    107KiB    0.5%  8.89KiB
   get node variables           12   3.53μs    0.0%   294ns     0.00B    0.0%    0.00B
   save mesh                    12    510ns    0.0%  42.5ns     0.00B    0.0%    0.00B
 a posteriori limiter          306   17.0ms    4.7%  55.5μs   34.9KiB    0.2%     117B
   blending factors            306   10.9ms    3.0%  35.5μs   34.2KiB    0.2%     114B
     positivity                306   9.31ms    2.6%  30.4μs   33.5KiB    0.2%     112B
     ~blending factors~        306   1.57ms    0.4%  5.13μs      752B    0.0%    2.46B
   ~a posteriori limiter~      306   6.12ms    1.7%  20.0μs      752B    0.0%    2.46B
 analyze solution                3   8.22ms    2.3%  2.74ms   8.93MiB   45.8%  2.98MiB
 calculate dt                  103   7.96ms    2.2%  77.3μs     0.00B    0.0%    0.00B
 ─────────────────────────────────────────────────────────────────────────────────────
```